### PR TITLE
Do not cache json files because of metalsmith-watch

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,7 @@ var joi  = require('joi');
 var each = require('async').each;
 var path = require('path');
 var slug = require('slug-component');
+var jsonfile = require('jsonfile');
 
 var resolve = _.get;
 
@@ -145,7 +146,7 @@ var plugin = function plugin (options) {
             var source_filepath = path.resolve(metalsmith.directory(), options.source_path + file_meta.json_files.source_file + '.json');
 
             // TODO: Check file exists and provide warning
-            var json = require(source_filepath);
+            var json = jsonfile.readFileSync(source_filepath);
 
             // log('File json: %o', json);
             json.forEach(function (element) {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "async": "^1.4.2",
     "debug": "^2.2.0",
     "joi": "^6.6.1",
+    "jsonfile": "^2.4.0",
     "lodash": "^3.10.1",
     "slug-component": "^1.1.0"
   },


### PR DESCRIPTION
When using `require`, JSON files are cached and are not reloaded when using [metalsmith-watch](https://github.com/FWeinb/metalsmith-watch). This PR changes `require` to `jsonfile.readFileSync` to fix that. 