### PR TITLE
added direct data passthrough ability and updated docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,28 @@ json_files:
 ---
 ```
 
+### Pass data directly (unwrapped) into the page
+
+By default JSON data is wrapped in a `data` object in the page, but sometimes we want to pass it directly as if we'd written it in front matter (eg. it might be handy to pass `tags` for use by other plugins).
+
+This can be achieved by using `passthrough`, an array of objects each containing:
+- the key of an object we wish to pass directly (`from`)
+- what we want to call it in the page (`to`)
+
+So the following example will pass `tags` directly into the page. It will also pass `date` into the page, renamed to `publishedDate`: 
+```md
+---
+name: My Posts
+template: posts.hbs
+json_files:
+  passthrough:
+    - from: tags
+      to: tags
+    - from: date
+      to: publishedDate
+---
+```
+
 
 ## Examples
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -83,7 +83,8 @@ const metadata_schema = {
   source_file: joi.string().required(),
   filename_pattern: joi.string().required(),
   as_permalink: joi.boolean(),
-  rename_data_to: joi.string()
+  rename_data_to: joi.string(),
+  passthrough: joi.array()
 };
 
 const metadata_schema_options = {
@@ -156,12 +157,19 @@ const plugin = options => {
       json.forEach(element => {
         const defaults = { contents: '' };
         const meta = file_meta.json_files;
+        const passthrough_ob = {};
 
 				let renamed_element_wrapper = {};
 				// use key from `rename_data_to`, or default to "data"
 				renamed_element_wrapper[meta.rename_data_to || 'data'] = element;
 
-				const data = extend(defaults, meta, renamed_element_wrapper);
+        // pass any chosen properties (eg. tags) from JSON directly into page metadata
+        if (meta.passthrough) {
+          for (let i = 0; i < meta.passthrough.length; i++) {
+            passthrough_ob[meta.passthrough[i].to] = element[meta.passthrough[i].from];
+          }
+        }
+				const data = extend(defaults, meta, renamed_element_wrapper, passthrough_ob);
 
         // Take into account the parent in build filename
         const filename = build_filename(data.filename_pattern, data);


### PR DESCRIPTION
Hi,
This allows selected data to pass directly (unwrapped) into the page. The below should help explain (copy/pasted from the updated README included in the PR).

By default JSON data is wrapped in a `data` object in the page, but sometimes we want to pass it directly as if we'd written it in front matter (eg. it might be handy to pass `tags` for use by other plugins).

This can be achieved by using `passthrough`, an array of objects each containing:
- the key of an object we wish to pass directly (`from`)
- what we want to call it in the page (`to`)

So the following example will pass `tags` directly into the page. It will also pass `date` into the page, renamed to `publishedDate`: 
```md
---
name: My Posts
template: posts.hbs
json_files:
  passthrough:
    - from: tags
      to: tags
    - from: date
      to: publishedDate
---
```